### PR TITLE
use relative schema for font import

### DIFF
--- a/source/css/_base/variable.styl
+++ b/source/css/_base/variable.styl
@@ -14,7 +14,7 @@ font-serif = "Georgia", serif
 font-mono = Monaco, Menlo, Consolas, Courier New, monospace
 font-title = "Pontano Sans", Helvetica Neue, Helvetica, Arial, sans-serif
 
-@import url("http://fonts.googleapis.com/css?family=Pontano+Sans");
+@import url("//fonts.googleapis.com/css?family=Pontano+Sans");
 
 font-icon = FontAwesome
 font-icon-path = 'font/fontawesome-webfont'


### PR DESCRIPTION
no more mixed content warning on https sites
