### PR TITLE
 fix: prevent </html> appearing after </head> 

### DIFF
--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -1,5 +1,3 @@
-<!DOCTYPE HTML>
-<html>
 <head>
   <meta charset="utf-8">
   <%

--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+ <html lang="<%= config.language %>"> 
 <%- partial('_partial/head') %>
 
 <body>

--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -1,3 +1,5 @@
+<!DOCTYPE html>
+<html>
 <%- partial('_partial/head') %>
 
 <body>


### PR DESCRIPTION
https://github.com/hexojs/hexo-theme-landscape/pull/123
https://github.com/hexojs/hexo/pull/3315
also add [language attribute](https://www.w3.org/International/questions/qa-html-language-declarations#attributes)
