### PR TITLE
fix(seo): use valid schema and add microformat

### DIFF
--- a/layout/_partial/article.ejs
+++ b/layout/_partial/article.ejs
@@ -1,4 +1,4 @@
-<article class="<% if (item.layout == 'page'){ %>page<% } else { %>post<% } %>">
+<article class="h-entry <% if (item.layout == 'page'){ %>page<% } else { %>post<% } %>" itemprop="blogPost" itemscope itemtype="https://schema.org/BlogPosting">
   <% if (item.photos){ %>
     <%- partial('post/gallery') %>
   <% } %>
@@ -6,7 +6,7 @@
     <%- partial('post/title') %>
     <% if (item.layout != 'page'){ %><%- partial('post/date') %><% } %>
   </header>
-  <div class="entry-content">
+  <div class="e-content entry-content">
     <% if (item.excerpt && index){ %>
       <%- item.excerpt %>
     <% } else { %>

--- a/layout/_partial/post/date.ejs
+++ b/layout/_partial/post/date.ejs
@@ -1,3 +1,3 @@
-<time datetime="<%= item.date.toDate().toISOString() %>">
+<time class="dt-published" datetime="<%= item.date.toDate().toISOString() %>">
   <span class="day"><%= item.date.format('D') %></span><span class="month"><%= item.date.format('MMM') %></span>
 </time>

--- a/layout/_partial/post/title.ejs
+++ b/layout/_partial/post/title.ejs
@@ -8,6 +8,6 @@
   <% if (index){ %>
     <h1 class="title"><a href="<%- config.root %><%- item.path %>"><%= item.title %></a></h1>
   <% } else { %>
-    <h1 class="title"><%= item.title %></h1>
+    <h1 class="p-name title" itemprop="headline name"><%= item.title %></h1>
   <% } %>
 <% } %>


### PR DESCRIPTION
This fix the `Unspecified type` schema issue identified by [Google](https://search.google.com/structured-data/testing-tool/).

`headline` class is only added to post title in an article, not archive/index.

Add [h-entry](http://microformats.org/wiki/h-entry) Microformat.

schema fix is based on [this example](https://github.com/philwareham/schema-microdata-examples/blob/master/blog.html).