### PR TITLE
feat: read disqus_shortname from theme config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,3 +18,5 @@ google_analytics:
 rss:
 # Display a "Read More" link under each post's excerpt in /archives page
 #excerpt_link: 'Read More'
+
+disqus_shortname:

--- a/layout/_partial/after_footer.ejs
+++ b/layout/_partial/after_footer.ejs
@@ -2,9 +2,9 @@
 <%- js('js/jquery.imagesloaded.min.js') %>
 <%- js('js/gallery.js') %>
 
-<% if (config.disqus_shortname){ %>
+<% if (theme.disqus_shortname){ %>
 <script>
-var disqus_shortname = '<%= config.disqus_shortname %>';
+var disqus_shortname = '<%= theme.disqus_shortname %>';
 
 (function(){
   var dsq = document.createElement('script');

--- a/layout/_partial/article.ejs
+++ b/layout/_partial/article.ejs
@@ -21,7 +21,7 @@
     <footer class="meta">
       <%- partial('post/category') %>
       <%- partial('post/tag') %>
-      <% if (config.disqus_shortname && item.comment){ %>
+      <% if (theme.disqus_shortname && item.comments){ %>
         <a href="<%- item.permalink %>#disqus_thread" class="comment"><%= __('comment') %></a>
       <% } %>
     </footer>

--- a/layout/_partial/comment.ejs
+++ b/layout/_partial/comment.ejs
@@ -1,4 +1,4 @@
-<% if (config.disqus_shortname && page.comments){ %>
+<% if (theme.disqus_shortname && page.comments){ %>
 <section id="comment">
   <div id="disqus_thread" aria-live="polite">
     <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>


### PR DESCRIPTION
In earlier versions of Hexo, themes needed to read the `disqus_shortname` from Hexo's `_config.yml` file as the configuration for the Disqus comment system. However, this option was deprecated around 2015 (https://github.com/hexojs/hexo-theme-unit-test/commit/8dd691e). Nowadays, many themes allow users to load different Disqus configuration options, and there are no unified regulations for this. Therefore, I plan to move the `disqus_shortname` option for the official Hexo theme from the Hexo configuration file to the theme configuration file.