### PR TITLE
fix: add url_for

### DIFF
--- a/layout/_partial/header.ejs
+++ b/layout/_partial/header.ejs
@@ -1,7 +1,7 @@
 <nav>
   <ul>
     <% for (var i in theme.menu){ %>
-      <li><a href="<%- theme.menu[i] %>"><%= i %></a></li>
+      <li><a href="<%- url_for(theme.menu[i]) %>"><%= i %></a></li>
     <% } %>
   </ul>
 </nav>


### PR DESCRIPTION

## check list

- Menu's URL

## Description

Returns the menu's URL with the root path prefixed.
